### PR TITLE
[update-postman-secrets-handling]

### DIFF
--- a/.github/workflows/api_reco_deploy.yml
+++ b/.github/workflows/api_reco_deploy.yml
@@ -51,6 +51,7 @@ jobs:
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 
   api-reco-test-integration:
+    if: ${{ needs.setup-job.outputs.env_name != 'dev'}}
     uses: ./.github/workflows/reusable_api_reco_integration_tests.yml
     needs: 
       - setup-job

--- a/.github/workflows/reusable_api_reco_integration_tests.yml
+++ b/.github/workflows/reusable_api_reco_integration_tests.yml
@@ -46,7 +46,7 @@ jobs:
         with:
            secrets: API_RECO_TOKEN:${{ env.DATA_GCP_PROJECT }}/${{ env.API_RECO_SECRET_NAME }}
       - name: Run tests collection
-        run: newman run api_integration_tests.postman_collection.json --environment ${{ inputs.TARGET_ENV }}.postman_environment.json
+        run: newman run api_integration_tests.postman_collection.json --environment ${{ inputs.TARGET_ENV }}.postman_environment.json --env-var "api_token=${{ steps.secrets.outputs.API_RECO_TOKEN }}"
       - name: Post to a Slack channel
         id: slack
         if: ${{ failure() }}


### PR DESCRIPTION
# Hotfix

## Describe your changes

Update secret handling via postman 

Please include a summary of the changes:

Add 'api_token' to Postman secrets 

This PR fixes the bug : Missing token for integration tests  

Tag a reviewer if necessacy  @github/username 

## Which API ?
- [x] API reco
- [ ] API papillon

### Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] My code passes CI/CD tests
- [x] I will create a review on slack. The review task should be short (<10min).