### PR TITLE
(reco)  fix: playlist_type 

### DIFF
--- a/apps/recommendation/api/src/huggy/schemas/playlist_params.py
+++ b/apps/recommendation/api/src/huggy/schemas/playlist_params.py
@@ -53,13 +53,13 @@ class PlaylistParams(BaseModel):
         return None
 
     def playlist_type(self):
-        if len(self.categories) > 1:
+        if self.categories and len(self.categories) > 1:
             return "multipleCategoriesRecommendations"
-        if len(self.categories) == 1:
+        if self.categories and len(self.categories) == 1:
             return "singleCategoryRecommendations"
-        if len(self.subcategories) > 1:
+        if self.subcategories and len(self.subcategories) > 1:
             return "multipleSubCategoriesRecommendations"
-        if len(self.subcategories) == 1:
+        if self.subcategories and len(self.subcategories) == 1:
             return "singleSubCategoryRecommendations"
         return "GenericRecommendations"
 


### PR DESCRIPTION
# Hotfix

## Describe your changes

Add case for empty 'categories' and 'subcategories' in PlaylistParams 'playlist_type'
This PR fixes the bug -> 
```
if len(self.categories) > 1:
TypeError: object of type 'NoneType' has no len()" 
```

Tag a reviewer if necessacy  @github/username 

## Jira ticket number and/or notion link

JIRA-ticket_number

## Which API ?
- [x] API reco
- [ ] API papillon

### Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] My code passes CI/CD tests
- [x] I will create a review on slack. The review task should be short (<10min).