### PR TITLE
(DE-784) fix(compliace): Remove deprecated offer_subcategoryid input

### DIFF
--- a/apps/fraud/compliance/api/src/pcpapillon/utils/data_model.py
+++ b/apps/fraud/compliance/api/src/pcpapillon/utils/data_model.py
@@ -26,7 +26,6 @@ class ComplianceInput(BaseModel):
     offer_id: Union[str, None] = ""
     offer_name: Union[str, None] = ""
     offer_description: Union[str, None] = ""
-    offer_subcategoryid: Union[str, None] = ""
     offer_subcategory_id: Union[str, None] = ""
     rayon: Union[str, None] = ""
     macro_rayon: Union[str, None] = ""

--- a/apps/fraud/compliance/api/src/pcpapillon/views/compliance.py
+++ b/apps/fraud/compliance/api/src/pcpapillon/views/compliance.py
@@ -27,24 +27,13 @@ compliance_scheduler = init_scheduler(
 )
 @version(1, 0)
 def model_compliance_scoring(scoring_input: ComplianceInput):
-    # To remove once we figure out the real issue
-    hotfix_input = scoring_input
-    hotfix_input.offer_subcategory_id = (
-        hotfix_input.offer_subcategoryid
-        if (
-            hotfix_input.offer_subcategoryid != ""
-            and hotfix_input.offer_subcategory_id == ""
-        )
-        else hotfix_input.offer_subcategory_id
-    )
-
     log_extra_data = {
         "model_version": "default_model",
-        "offer_id": hotfix_input.dict()["offer_id"],
-        "scoring_input": hotfix_input.dict(),
+        "offer_id": scoring_input.dict()["offer_id"],
+        "scoring_input": scoring_input.dict(),
     }
 
-    predictions = compliance_model.predict(data=hotfix_input)
+    predictions = compliance_model.predict(data=scoring_input)
 
     custom_logger.info(predictions.dict(), extra=log_extra_data)
     return predictions


### PR DESCRIPTION
# Generic PR

## Describe your changes

- Remove deprecated input for compliance API (offer_subcategoryid -> offer_subcategory_id)


## Which API ?
- [ ] API reco
- [ ] API papillon

### Type of change
- [ ] New model
- [ ] New endpoint
- [ ] New route
- [ ] Deletion -> what ?:
- [ ] Code Refacto and performance Improvements
- [ ] Testing
- [ ] CI
- [ ] Config


### Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] My code passes CI/CD tests
- [ ] I updated README.md
- [ ] My PR contains only a single commit (squash them if needed)
- [ ] I will create a review on slack and ensure to specify the duration of the review task: short (<10min), medium (<30min), long (>30min)

### Added tests?
- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] ⏰ no, but I created a ticket
