### PR TITLE
(BSR) fix(reco_v2): allow explicit env override via DOTENV_OVERRIDE

### DIFF
--- a/apps/recommendation_v2/Makefile
+++ b/apps/recommendation_v2/Makefile
@@ -132,6 +132,7 @@ streamlit-remote: check-gcloud-auth ## Start Streamlit UI against a remote API v
 	trap 'echo -e "\n🛑 Closing SOCKS tunnel (PID: $$TUNNEL_PID)..."; kill $$TUNNEL_PID 2>/dev/null || true' EXIT INT TERM ; \
 	echo "✅ Tunnel SOCKS ouvert sur le port $$SOCKS_PORT" ; \
 	echo "👉 Dans le Streamlit, configurez le proxy : socks5://localhost:$$SOCKS_PORT" ; \
+	DOTENV_OVERRIDE=0 \
 	REMOTE_API_URL="$$REMOTE_API_URL" \
 	REMOTE_API_V1_URL="$$REMOTE_API_V1_URL" \
 	REMOTE_API_TOKEN="$$REMOTE_API_TOKEN" \

--- a/apps/recommendation_v2/src/config/settings.py
+++ b/apps/recommendation_v2/src/config/settings.py
@@ -16,7 +16,15 @@ from dotenv import load_dotenv
 # --- 1. Environment Loading ---
 # Resolve the path to the .env file located at the root of the src directory
 environment_file_path = Path(".env")
-load_dotenv(dotenv_path=environment_file_path, override=False)
+
+# override=True (default) allows uvicorn's hot-reload to pick up .env changes at runtime
+# (uvicorn is configured with reload_includes=[".env"], which triggers a module reimport).
+# When running remote commands (streamlit-remote), the shell pre-loads
+# the environment from .env.<DEPLOY_ENV> BEFORE the Python process starts. In that case,
+# the Makefile injects DOTENV_OVERRIDE=0 so that load_dotenv does NOT override the env vars
+# already set in the process environment, letting .env.<DEPLOY_ENV> values take precedence.
+_dotenv_override: bool = bool(int(os.environ.get("DOTENV_OVERRIDE", "1")))
+load_dotenv(dotenv_path=environment_file_path, override=_dotenv_override)
 
 
 # --- 2. Application Environment ---


### PR DESCRIPTION
- Introduce DOTENV_OVERRIDE in settings.py to control priority between .env file and system environment.
- Default to 1 (override enabled) for local development and hot-reload support.
- Set to 0 in Makefile remote commands (streamlit-remote, access-remote-swagger) to ensure shell-loaded configs (like .env.prod) take precedence over local .env.

# Generic PR

## Describe your changes

Please include a summary of the changes:

This PR [adds/removes/fixes/replaces] the [feature/bug/etc].

Tag a reviewer if necessacy  @github/username

## Jira ticket number and/or notion link

JIRA-ticket_number

## Which API ?
- [ ] API reco
- [ ] API papillon

### Type of change
- [ ] New model
- [ ] New endpoint
- [ ] New route
- [ ] Deletion -> what ?:
- [ ] Code Refacto and performance Improvements
- [ ] Testing
- [ ] CI
- [ ] Config


### Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] My code passes CI/CD tests
- [ ] I updated README.md
- [ ] My PR contains only a single commit (squash them if needed)
- [ ] I will create a review on slack and ensure to specify the duration of the review task: short (<10min), medium (<30min), long (>30min)

### Added tests?
- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] ⏰ no, but I created a ticket
