### PR TITLE
(DE-3947) feat(reco_v2): add LogLevel enum to benchmark decorator to track route perf in cloudrun monitoring

### DIFF
--- a/apps/recommendation_v2/src/api/playlist_recommendation.py
+++ b/apps/recommendation_v2/src/api/playlist_recommendation.py
@@ -16,6 +16,7 @@ from schemas.playlist_recommendation import RecommendationResponse
 from services.db import get_database_session
 from services.h3 import get_h3_index_from_coordinates
 from services.logger import logger
+from utils.benchmark import LogLevel
 from utils.benchmark import log_execution_time
 from utils.location_presets import PRESET_LOCATION_TO_GEOGRAPHIC_COORDINATES_MAPPING
 
@@ -28,7 +29,7 @@ router = APIRouter()
     response_model=RecommendationResponse,
     summary="Generate a personalized recommendation playlist",
 )
-@log_execution_time
+@log_execution_time(level=LogLevel.INFO)
 async def get_playlist(
     params: Annotated[PlaylistRequestParams, Body(...)],
     db: Annotated[AsyncSession, Depends(get_database_session)],

--- a/apps/recommendation_v2/src/api/similar_offer.py
+++ b/apps/recommendation_v2/src/api/similar_offer.py
@@ -19,6 +19,7 @@ from schemas.similar_offer import SimilarOfferResponse
 from services.db import get_database_session
 from services.h3 import get_h3_index_from_coordinates
 from services.logger import logger
+from utils.benchmark import LogLevel
 from utils.benchmark import log_execution_time
 from utils.location_presets import PRESET_LOCATION_TO_GEOGRAPHIC_COORDINATES_MAPPING
 
@@ -31,7 +32,7 @@ router = APIRouter()
     response_model=SimilarOfferResponse,
     summary="Generate similar offer recommendations",
 )
-@log_execution_time
+@log_execution_time(level=LogLevel.INFO)
 async def get_similar_offers(  # noqa: PLR0913
     db: Annotated[AsyncSession, Depends(get_database_session)],
     location: Annotated[LocationParams, Depends()],

--- a/apps/recommendation_v2/src/utils/benchmark.py
+++ b/apps/recommendation_v2/src/utils/benchmark.py
@@ -4,44 +4,60 @@ Benchmarking Utilities for SQL Queries.
 This module provides tools to measure and analyze the performance of database interactions.
 """
 
+import enum
 import time
 from functools import wraps
 
 from services.logger import logger
 
 
-def log_execution_time(func):
+class LogLevel(enum.Enum):
+    DEBUG = "debug"
+    INFO = "info"
+    WARNING = "warning"
+    ERROR = "error"
+
+
+def log_execution_time(_func=None, *, level: LogLevel = LogLevel.DEBUG):
     """
     Decorator to measure and log the execution time of an asynchronous function.
 
     Args:
         func (Callable): The asynchronous function to measure.
+        level (LogLevel): The log level to use. Defaults to DEBUG.
 
     Returns:
         Callable: The wrapped function with timing logic.
     """
 
-    @wraps(func)
-    async def wrapper(*args, **kwargs):
-        start_time = time.perf_counter()
-        result = await func(*args, **kwargs)
-        end_time = time.perf_counter()
-        execution_time = end_time - start_time
+    def decorator(func):
+        @wraps(func)
+        async def wrapper(*args, **kwargs):
+            start_time = time.perf_counter()
+            result = await func(*args, **kwargs)
+            end_time = time.perf_counter()
+            execution_time = end_time - start_time
 
-        from_cache = getattr(result, "from_cache", None)
-        cache_info = ""
-        extra: dict = {"function": func.__name__, "execution_time_seconds": execution_time}
+            from_cache = getattr(result, "from_cache", None)
+            cache_info = ""
+            extra: dict = {"function": func.__name__, "execution_time_seconds": execution_time}
 
-        if from_cache is not None:
-            cache_label = "CACHE HIT 🟢" if from_cache else "CACHE MISS 🔴"
-            cache_info = f" | {cache_label}"
-            extra["from_cache"] = from_cache
+            if from_cache is not None:
+                cache_label = "CACHE HIT 🟢" if from_cache else "CACHE MISS 🔴"
+                cache_info = f" | {cache_label}"
+                extra["from_cache"] = from_cache
 
-        logger.debug(
-            f"⏱️ [BENCHMARK] Function '{func.__name__}' executed in {execution_time:.4f} seconds{cache_info}.",
-            extra=extra,
-        )
+            log_fn = getattr(logger, level.value)
+            log_fn(
+                f"⏱️ [BENCHMARK] Function '{func.__name__}' executed in {execution_time:.4f} seconds{cache_info}.",
+                extra=extra,
+            )
 
-        return result
+            return result
 
-    return wrapper
+        return wrapper
+
+    # Support both @log_execution_time(level=LogLevel.INFO) and @log_execution_time without parenthesis
+    if _func is not None:
+        return decorator(_func)
+    return decorator


### PR DESCRIPTION


### Select PR template in preview mode:
* [Ticket](?expand=1&template=Generic_template.md)
* [Hotfix](?expand=1&template=Hotfix_template.md)
* [MES](?expand=1&template=MES_template.md)
* [MEP](?expand=1&template=MEP_template.md)



<!-- Markdown tips:

To tick boxe replace [ ] with [x]

 -->


 <!--
TO DO: check with repo admin : [https://passculture.atlassian.net/browse/PC-<num>](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources)

JIRA-replace_with_ticket_number

[Notion-link](paste within parenthesis)
-->
